### PR TITLE
Fix cross-namespace Postgres connection resolution

### DIFF
--- a/pkg/postgres/client.go
+++ b/pkg/postgres/client.go
@@ -59,8 +59,13 @@ func (c *Client) getConnectionDetails(ctx context.Context, pgConn *postgresv1.Po
 	if port == 0 {
 		port = 5432
 	}
+
 	if host == "" {
-		host = fmt.Sprintf("%s-rw", pgConn.Spec.ClusterName)
+		clusterNamespace := pgConn.Spec.ClusterNamespace
+		if clusterNamespace == "" {
+			clusterNamespace = pgConn.Namespace
+		}
+		host = fmt.Sprintf("%s-rw.%s.svc", pgConn.Spec.ClusterName, clusterNamespace)
 	}
 
 	username, password, err := c.getCredentials(ctx, pgConn)
@@ -82,7 +87,10 @@ func (c *Client) getCredentials(ctx context.Context, pgConn *postgresv1.PostGres
 		}
 	} else {
 		secretName = fmt.Sprintf("%s-superuser", pgConn.Spec.ClusterName)
-		secretNamespace = pgConn.Namespace
+		secretNamespace = pgConn.Spec.ClusterNamespace
+		if secretNamespace == "" {
+			secretNamespace = pgConn.Namespace
+		}
 	}
 
 	var secret corev1.Secret

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -39,7 +39,7 @@ var _ = Describe("PostgreSQL Operator", Ordered, func() {
 		connectionName   = "test-connection"
 		databaseName     = "test-database"
 		crossNsNamespace = "test-app"
-		timeout          = 10 * time.Minute
+		timeout          = 15 * time.Minute
 		interval         = 5 * time.Second
 	)
 


### PR DESCRIPTION
## Summary
- ensure PostGresConnection uses cluster namespace when resolving host and secret location
- give E2E operator tests more time to wait for readiness

## Testing
- `go test ./... -run TestNonexistent` *(fails: unrecognized import path "k8s.io/apimachinery": https fetch 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b15170ae6c832f95f0e12e346fcc97