### PR TITLE
Use go test coverage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -coverprofile=coverage.out $$(go list ./... | grep -v /e2e)
+	go tool cover -html=coverage.out -o coverage.html
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.


### PR DESCRIPTION
## Summary
- switch test target to `go test -coverprofile=coverage.out` and generate HTML coverage

## Testing
- `go test -coverprofile=coverage.out $(go list ./... | grep -v /e2e)` *(fails: coverage only, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b183a09e38832f991d0bc1b8ece662