### PR TITLE
Avoid redundant envtest extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet setup-envtest ## Run tests.
+test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -coverprofile=coverage.out $$(go list ./... | grep -v /e2e)
 	go tool cover -html=coverage.out -o coverage.html
 


### PR DESCRIPTION
## Summary
- fix `make test` to avoid double envtest downloads that caused tar extraction errors

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b31f112d7c832f837723059af314d3