### PR TITLE
chore: remove coverage tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" bash -c 'set -euo pipefail; echo "mode: set" > coverage.out; for pkg in $(shell go list ./... | grep -v /e2e); do go test -coverprofile=profile.out $$pkg; if [ -f profile.out ]; then tail -n +2 profile.out >> coverage.out; rm profile.out; fi; done'
-	go tool cover -html=coverage.out -o coverage.html
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	go test $(shell go list ./... | grep -v /e2e)
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -244,7 +244,6 @@ scripts/
 - Unit tests for service layer components
 - Integration tests with real PostgreSQL
 - E2E tests with CNPG clusters in kind
-- Automated coverage reporting
 
 ## Design Decisions
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -137,7 +137,6 @@ This project adheres to a code of conduct that we expect all contributors to fol
 - Write unit tests for new functions
 - Test error conditions and edge cases
 - Mock external dependencies
-- Maintain or improve code coverage
 
 ### Documentation Standards
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,9 +92,9 @@ fi
 # Run tests before release
 echo "🧪 Running tests..."
 if [[ "$DRY_RUN" == "false" ]]; then
-    ./scripts/test.sh --coverage
+    ./scripts/test.sh
 else
-    echo "   Would run: ./scripts/test.sh --coverage"
+    echo "   Would run: ./scripts/test.sh"
 fi
 
 # Generate manifests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Comprehensive test script for pg-operator
-# Runs unit tests, integration tests, and generates coverage reports
+# Runs unit, integration, and e2e tests
 
 set -euo pipefail
 
@@ -8,7 +8,6 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Default values
-COVERAGE=false
 VERBOSE=false
 RACE=false
 INTEGRATION=false
@@ -18,10 +17,6 @@ PACKAGE="./..."
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -c|--coverage)
-            COVERAGE=true
-            shift
-            ;;
         -v|--verbose)
             VERBOSE=true
             shift
@@ -45,7 +40,6 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
-            echo "  -c, --coverage     Generate coverage report"
             echo "  -v, --verbose      Verbose output"
             echo "  -r, --race         Enable race detector"
             echo "  -i, --integration  Run integration tests"
@@ -70,14 +64,6 @@ if [[ "$VERBOSE" == "true" ]]; then
 fi
 if [[ "$RACE" == "true" ]]; then
     TEST_FLAGS+=("-race")
-fi
-if [[ "$COVERAGE" == "true" ]]; then
-    TEST_FLAGS+=("-coverprofile=coverage.out" "-covermode=atomic")
-fi
-
-# Clean previous coverage files
-if [[ "$COVERAGE" == "true" ]]; then
-    rm -f coverage.out coverage.html
 fi
 
 # Run unit tests
@@ -127,21 +113,5 @@ if [[ "$E2E" == "true" ]]; then
     go test "${TEST_FLAGS[@]}" -tags=e2e ./test/e2e/...
 fi
 
-# Generate coverage report
-if [[ "$COVERAGE" == "true" ]] && [[ -f "coverage.out" ]]; then
-    echo "📊 Generating coverage report..."
-    go tool cover -html=coverage.out -o coverage.html
-    
-    # Calculate coverage percentage
-    COVERAGE_PERCENT=$(go tool cover -func=coverage.out | grep total | awk '{print $3}')
-    echo "📈 Total coverage: $COVERAGE_PERCENT"
-    
-    if command -v open &> /dev/null; then
-        echo "🌐 Opening coverage report in browser..."
-        open coverage.html
-    else
-        echo "📄 Coverage report saved to coverage.html"
-    fi
-fi
-
 echo "✅ Tests completed successfully!"
+ 


### PR DESCRIPTION
## Summary
- drop coverage script and configuration
- streamline test script and release workflow
- tidy docs to avoid coverage references

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b42ae2fa68832fabe108f9d63afb62